### PR TITLE
feat: Add flexible configuration path overrides and simplify documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,6 @@ Thumbs.db
 coverage.xml
 coverage_report.xml
 */.coverage
-htmlcov/ 
+htmlcov/
+test_logs/
+coverage_html/ 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.5  # Use the latest version from https://github.com/astral-sh/ruff-pre-commit/releases
+    hooks:
+    -   id: ruff
+        args: [--fix, --verbose, --preview]
+    -   id: ruff-format
+
+# Optionally you could add other hooks like:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0  # Use the latest version from https://github.com/pre-commit/pre-commit-hooks/releases
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files 
+
+# Code coverage check using the optimized local script that matches CI thresholds
+-   repo: local
+    hooks:
+    -   id: test-coverage
+        name: Check test coverage
+        entry: bash scripts/run_coverage_local.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
+        # Can be skipped with SKIP=test-coverage git commit -m "..."
+        stages: [pre-commit] 

--- a/README.md
+++ b/README.md
@@ -4,318 +4,93 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=BlueCentre_cli-code&metric=coverage)](https://sonarcloud.io/summary/new_code?id=BlueCentre_cli-code)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=BlueCentre_cli-code&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=BlueCentre_cli-code)
 
-An AI coding assistant for your terminal, powered by multiple LLM providers (Gemini and Ollama).
+An AI coding assistant for your terminal, powered by multiple LLM providers (currently Google Gemini and Ollama).
 
 **Table of Contents**
 
 - [Features](#features)
 - [Installation](#installation)
-  - [Method 1: Install from PyPI (Recommended)](#method-1-install-from-pypi-recommended)
-  - [Method 2: Install from Source](#method-2-install-from-source)
 - [Setup](#setup)
-  - [Alternative Setup Using Environment Variables](#alternative-setup-using-environment-variables)
-  - [Configuration File](#configuration-file)
 - [Usage](#usage)
-- [Interactive Commands](#interactive-commands)
 - [Documentation](#documentation)
-- [How It Works](#how-it-works)
-  - [Tool Usage](#tool-usage)
-- [Advanced Features](#advanced-features)
-  - [Custom Context with `.rules`](#custom-context-with-rules)
-- [Development](#development)
 - [Contributing](#contributing)
 - [License](#license)
-- [Running Tests](#running-tests)
 
 ## Features
 
-- Interactive chat sessions in your terminal
-- Multiple model provider support (Google Gemini, Ollama - more planned)
-- Configurable default provider and model
-- Hierarchical context initialization from:
-  - `.rules/*.md` files (if directory exists)
-  - `README.md` file (fallback)
-  - Directory listing (final fallback)
-- Basic history management (prevents excessive length)
-- Markdown rendering in the terminal
-- Automatic tool usage by the assistant:
-  - File operations (view, edit, list, grep, glob)
-  - Directory operations (ls, tree, create_directory)
-  - System commands (bash)
+- Interactive chat sessions in your terminal.
+- Supports multiple model providers (Google Gemini, Ollama).
+- Configurable default provider and model.
+- Automatic context initialization from project files.
+- Markdown rendering for chat output.
+- Assistant can utilize tools for:
+  - File operations (view, edit, list, grep, search)
+  - Directory operations (list, tree)
+  - System commands (run terminal commands)
   - Quality checks (linting, formatting)
-  - Test running capabilities (pytest, etc.)
+  - Running tests (e.g., pytest)
 
 ## Installation
 
-### Method 1: Install from PyPI (Recommended)
+For detailed installation instructions, please see the [Installation Guide](docs/install.md).
 
+**Recommended (PyPI):**
 ```bash
-# Install directly from PyPI
 pip install cli-code-agent
 ```
 
-### Method 2: Install from Source
-
+**From Source:**
 ```bash
-# Clone the repository
 git clone https://github.com/BlueCentre/cli-code.git
 cd cli-code
-
-# Install the package
 pip install -e .
 ```
 
 ## Setup
 
-Before using CLI Code, you need to set up API credentials for your desired provider:
+Configure API credentials for your desired LLM provider. See the [Installation Guide](docs/install.md) for details on setup commands and using environment variables.
 
+**Example (Gemini):**
 ```bash
-# Set up Google API key for Gemini models
 cli-code-agent setup --provider=gemini YOUR_GOOGLE_API_KEY
-
-# OR Set up Ollama endpoint URL (if running Ollama locally or elsewhere)
-# cli-code-agent setup --provider=ollama YOUR_OLLAMA_API_URL
 ```
 
-### Alternative Setup Using Environment Variables
-
-You can also configure CLI Code using environment variables, either by setting them directly or using a `.env` file:
-
-1. Create a `.env` file in your working directory (copy from `.env.example`):
-   ```bash
-   cp .env.example .env
-   ```
-
-2. Edit the `.env` file and uncomment/modify the settings you need:
-   ```
-   # API Keys and URLs
-   CLI_CODE_GOOGLE_API_KEY=your_google_api_key_here
-   CLI_CODE_OLLAMA_API_URL=http://localhost:11434/v1
-   
-   # Default Provider
-   CLI_CODE_DEFAULT_PROVIDER=ollama
-   
-   # Default Model
-   CLI_CODE_OLLAMA_DEFAULT_MODEL=llama3.2:latest
-   ```
-
-3. Run CLI Code normally, and it will automatically load the settings from your `.env` file:
-   ```bash
-   cli-code-agent
-   ```
-
-The environment variables take precedence over saved configuration, making this approach useful for temporary settings or project-specific configurations.
-
-## Configuration File
-
-CLI Code uses a configuration file located at `~/.config/cli-code-agent/config.yaml` to store settings like API keys/URLs, default providers/models, and other preferences. The file is created with defaults the first time you run the setup or the application.
-
-You can edit this file directly. Here's an example structure:
-
-```yaml
-# ~/.config/cli-code-agent/config.yaml
-
-google_api_key: YOUR_GEMINI_API_KEY_HERE # Or null if using environment variable
-ollama_api_url: http://localhost:11434/v1 # Or null if not using Ollama/using env var
-
-default_provider: gemini # Can be 'gemini' or 'ollama'
-default_model: models/gemini-2.5-pro-exp-03-25 # Your preferred default Gemini model
-ollama_default_model: llama3.2 # Your preferred default Ollama model
-
-settings:
-  max_tokens: 1000000 # Maximum token limit for models
-  temperature: 0.5 # Model generation creativity (0.0 - 1.0)
-  token_warning_threshold: 800000 # Display a warning if context approaches this limit
-  auto_compact_threshold: 950000 # Attempt to compact history if context exceeds this
-```
-
-**Note:** Environment variables (like `CLI_CODE_GOOGLE_API_KEY`) will override the values set in this file.
+Configuration is typically stored in `~/.config/cli-code/config.yaml`, but can be overridden by environment variables or a custom file path.
 
 ## Usage
 
+Start an interactive chat session:
 ```bash
-# Start an interactive session with the default provider/model
+# Use default provider/model
 cli-code-agent
 
-# Start a session with a specific provider (uses provider's default model)
+# Specify provider (uses provider's default model)
 cli-code-agent --provider=ollama
 
-# Start a session with a specific provider and model
+# Specify provider and model
 cli-code-agent --provider=ollama --model llama3
-
-# Start a session with Gemini and a specific model
-cli-code-agent --provider=gemini --model models/gemini-1.5-pro-latest
-
-# Set default provider and model (example)
-# cli-code-agent set-default-provider ollama
-# cli-code-agent set-default-model llama3
-
-# List available models for a specific provider
-cli-code-agent list-models --provider=gemini
-cli-code-agent list-models --provider=ollama
 ```
 
-## Interactive Commands
-
-During an interactive session, you can use these commands:
-
-- `/exit` - Exit the chat session
-- `/help` - Display help information
+**Interactive Commands:**
+- `/exit` - Exit the chat session.
+- `/help` - Display help information.
 
 ## Documentation
 
-For more detailed information, please refer to the following documentation:
+Detailed documentation is available in the `docs/` directory:
 
-- [Installation Guide](docs/install.md) - Detailed instructions for installing and configuring CLI-Code
-- [Contributing Guide](docs/contributing.md) - Guidelines for contributing to the project
-- [Code Coverage Guide](docs/CODE_COVERAGE.md) - Information on code coverage tools and practices
-- [Changelog](docs/changelog.md) - History of changes and releases
-- [Architecture](docs/architecture.md) - Technical overview of the system architecture
-- [Context Guidelines](docs/context.md) - Guidelines for the CLI Code Assistant
-- [Project Brainstorm](docs/brainstorm.md) - Original brainstorming document for the CLI tool
-
-## How It Works
-
-### Tool Usage
-
-Unlike direct command-line tools, the CLI Code assistant uses tools automatically to help answer your questions. For example:
-
-**Example Interaction:**
-
-```
-You: What python files are in the src/cli_code directory?
-
-A:
-[tool_code]
-print(default_api.list_dir(relative_workspace_path='src/cli_code'))
-[/tool_code]
-[tool_output]
-{
-  "list_dir_response": {
-    "results": ["Contents of directory:\n\n[file] main.py ...\n[file] config.py ...\n..."]
-  }
-}
-[/tool_output]
-Okay, I found the following Python files in `src/cli_code/`:
-- `main.py`
-- `config.py`
-- `__init__.py`
-- `utils.py`
-
-There are also `models/` and `tools/` subdirectories containing more Python files.
-```
-
-This approach makes the interaction more natural, as you don't need to know the specific tool names or commands.
-
-## Advanced Features
-
-### Custom Context with `.rules`
-
-The CLI Code assistant can be customized with project-specific context by creating a `.rules` directory in your project root. Any markdown files (`.md`) placed in this directory will be automatically loaded as context when the assistant starts in that directory.
-
-This allows you to:
-- Define project-specific guidelines
-- Provide architectural constraints
-- Set coding standards
-- Describe the project's purpose and goals
-
-Example: Create a file `.rules/python_standards.md` with your team's Python coding standards, and the assistant will follow those guidelines when helping with your Python code.
-
-## Development
-
-To set up a development environment:
-
-```bash
-# Clone the repository
-git clone https://github.com/BlueCentre/cli-code.git
-cd cli-code
-
-# Install in development mode with dev dependencies
-pip install -e ".[dev]"
-
-# Run tests
-python -m pytest
-
-# Run coverage analysis with the new convenience script
-python run_tests_with_coverage.py --html
-
-# For more options:
-python run_tests_with_coverage.py --help
-
-### Running Tests Reliably
-
-When running tests, use these approaches for better control and reliability:
-
-```bash
-# Run specific test files
-python -m pytest tests/models/test_ollama_model_context.py
-
-# Run specific test classes or methods
-python -m pytest tests/models/test_ollama_model_context.py::TestOllamaModelContext
-python -m pytest tests/models/test_ollama_model_context.py::TestOllamaModelContext::test_clear_history
-
-# Use pattern matching with -k to select specific tests
-python -m pytest -k "tree_tool or ollama_context"
-
-# Exclude problematic tests with pattern matching
-python -m pytest -k "not config_comprehensive"
-
-# Run tests in parallel for faster execution
-pip install pytest-xdist
-python -m pytest -xvs -n 4
-
-# Monitor test progress with output redirection
-python -m pytest > test_results.log 2>&1 & 
-tail -f test_results.log
-```
-
-The project uses [pytest](https://docs.pytest.org/) for testing and [SonarCloud](https://sonarcloud.io/) for code quality and coverage analysis.
-
-### Code Coverage
-
-We've implemented comprehensive code coverage tracking to ensure the quality and reliability of the codebase. Coverage reports are generated in HTML and XML formats for:
-
-- Local development with the `run_tests_with_coverage.py` script
-- CI/CD pipeline with GitHub Actions
-- SonarCloud analysis for visualizing coverage over time
-
-To improve code coverage, focus on:
-1. Adding tests for any new code
-2. Identifying and filling gaps in existing test coverage
-3. Testing edge cases and error handling paths
-
-Our coverage goal is to maintain at least 70% overall code coverage.
+- [Installation & Setup](docs/install.md)
+- [Contributing Guide](docs/contributing.md)
+- [Code Coverage](docs/CODE_COVERAGE.md)
+- [Changelog](docs/changelog.md)
+- [Architecture](docs/architecture.md)
+- [Context Guidelines](docs/context.md)
+- [Project Brainstorm](docs/brainstorm.md)
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome! Please see the [Contributing Guide](docs/contributing.md) for details on setting up a development environment and submitting pull requests.
 
 ## License
 
 MIT
-
-## Running Tests
-
-The test suite is divided into two categories:
-
-1. **Core Tests** - Tests that don't require API access and run quickly:
-   ```bash
-   ./run_core_tests.sh
-   ```
-
-2. **API-Dependent Tests** - Tests that require access to external APIs (Ollama, Gemini):
-   ```bash
-   ./run_api_tests.sh
-   ```
-
-3. **All Tests** - Run all tests with a timeout to prevent hanging:
-   ```bash
-   ./run_all_tests.sh
-   ```
-
-Alternatively, you can run pytest directly:
-```bash
-python -m pytest
-```
-
-Note that running all tests without a timeout may cause hanging if API services are not available.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,7 +10,7 @@ Thank you for your interest in contributing to CLI-Code! This document outlines 
   ```bash
   # Generate coverage report
   pytest --cov=src tests --cov-report=xml
-  
+
   # Run local SonarCloud scan
   sonar-scanner -Dsonar.login=YOUR_SONARCLOUD_TOKEN
   ```
@@ -42,7 +42,7 @@ Thank you for your interest in contributing to CLI-Code! This document outlines 
   ```bash
   # Generate final coverage report
   pytest --cov=src tests --cov-report=xml
-  
+
   # Run local SonarCloud scan
   sonar-scanner -Dsonar.login=YOUR_SONARCLOUD_TOKEN
   ```
@@ -87,7 +87,7 @@ For the fastest feedback loop, run SonarCloud analysis locally before pushing ch
    ```bash
    # On macOS with Homebrew
    brew install sonar-scanner
-   
+
    # On NixOS
    nix-env -iA nixpkgs.sonar-scanner-cli.out
    ```
@@ -101,11 +101,11 @@ For the fastest feedback loop, run SonarCloud analysis locally before pushing ch
    ```bash
    # Option 1: Pass token directly (do not commit this command!)
    sonar-scanner -Dsonar.login=YOUR_SONARCLOUD_TOKEN
-   
+
    # Option 2: Use environment variable (recommended)
    export SONAR_TOKEN=YOUR_SONARCLOUD_TOKEN
    sonar-scanner
-   
+
    # Option 3: Add to ~/.bash_profile or ~/.zshrc (for convenience)
    # export SONAR_TOKEN=YOUR_SONARCLOUD_TOKEN
    ```
@@ -114,4 +114,56 @@ For the fastest feedback loop, run SonarCloud analysis locally before pushing ch
 
 4. Review the results and address any issues before pushing.
 
-This local workflow complements (but doesn't replace) the GitHub Actions workflow that runs automatically on push. 
+This local workflow complements (but doesn't replace) the GitHub Actions workflow that runs automatically on push.
+
+## Pre-commit Hooks
+
+Pre-commit hooks automatically check your code before each commit to ensure it meets quality standards and passes linting. This helps prevent CI/CD pipeline failures and ensures consistent code quality.
+
+### Setup
+
+We've provided a script to easily install pre-commit hooks:
+
+```bash
+# Run the provided setup script
+./scripts/setup_pre_commit.sh
+```
+
+This will:
+1. Install pre-commit if it's not already installed
+2. Set up the git hooks from our configuration
+3. Run the hooks against all files to verify setup
+
+### Available Hooks
+
+The following checks run automatically before each commit:
+
+1. **Ruff Linting**: Checks Python code for style issues and common problems
+2. **Ruff Formatting**: Ensures consistent code formatting
+3. **Additional Quality Checks**:
+   - Trailing whitespace removal
+   - End-of-file fixer (ensures files end with a newline)
+   - YAML syntax validation
+   - Prevention of large file commits
+
+### Bypass Hooks Temporarily
+
+If you need to bypass the hooks temporarily (not recommended), you can use:
+
+```bash
+git commit -m "Your message" --no-verify
+```
+
+### Manual Execution
+
+You can also run the hooks manually at any time:
+
+```bash
+# Run on all files
+pre-commit run --all-files
+
+# Run on staged files only
+pre-commit run
+```
+
+This local validation ensures your code meets project standards before submission and prevents linting-related CI failures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "cli-code-agent" 
-version = "0.3.0"  
+name = "cli-code-agent"
+version = "0.3.0"
 authors = [
   { name="James Nguyen", email="git@nocentre.net" }
 ]
@@ -43,6 +43,7 @@ dev = [
     "pytest-mock>=3.6.0", # Add pytest-mock dependency for mocker fixture
     "ruff>=0.1.0",    # For linting and formatting
     "protobuf>=4.0.0", # Also add to dev dependencies
+    "pre-commit>=3.5.0",  # For pre-commit hooks
     # Add other dev tools like coverage, mypy etc. here if needed
 ]
 

--- a/scripts/run_coverage_local.sh
+++ b/scripts/run_coverage_local.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Script optimized for pre-commit hook usage to check coverage quickly
+# Ensures complete consistency with CI pipeline coverage checks
+
+set -e  # Exit on error
+
+# Use colors for better readability
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Starting coverage check (using same configuration as CI)...${NC}"
+
+# Create required directories
+mkdir -p coverage_html test_logs
+
+# Install toml if not available
+python -c "import toml" 2>/dev/null || pip install toml >/dev/null
+
+# Extract the coverage threshold from pyproject.toml
+MIN_COVERAGE=$(python -c "import toml; data = toml.load('pyproject.toml'); print(data.get('tool', {}).get('coverage', {}).get('report', {}).get('fail_under', 60))")
+echo -e "Using minimum coverage threshold: ${GREEN}${MIN_COVERAGE}%${NC}"
+
+# Clean up any pycache files to avoid import conflicts (like in CI)
+find . -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
+find . -name "*.pyc" -delete
+
+# Set up logging
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+SUMMARY_LOG="test_logs/test_summary_${TIMESTAMP}.log"
+echo "Test run started at $(date)" > "$SUMMARY_LOG"
+
+# Run tests with coverage enabled - identical flags to CI script
+echo -e "${YELLOW}Running tests with coverage...${NC}"
+python -m pytest \
+  --cov=src/cli_code \
+  --cov-report=xml:coverage.xml \
+  --cov-report=html:coverage_html \
+  --cov-report=term-missing \
+  tests/ > test_logs/pytest_output.log 2>&1
+
+EXIT_CODE=$?
+
+# Check if coverage.xml exists
+if [ ! -f coverage.xml ]; then
+  echo -e "${RED}No coverage report was generated! Tests may have failed.${NC}"
+  echo -e "${YELLOW}See test output in test_logs/pytest_output.log${NC}"
+  cat test_logs/pytest_output.log
+  exit 1
+fi
+
+# Extract coverage percentage using XML report
+COVERAGE_PCT=$(python -c "import xml.etree.ElementTree as ET; tree = ET.parse('coverage.xml'); root = tree.getroot(); print(float(root.attrib['line-rate']) * 100)")
+
+# Format coverage to 2 decimal places
+COVERAGE_PCT=$(printf "%.2f" $COVERAGE_PCT)
+
+echo -e "${YELLOW}Coverage: ${GREEN}${COVERAGE_PCT}%${NC}"
+echo -e "Minimum required: ${YELLOW}${MIN_COVERAGE}%${NC}"
+
+# Summary in log file (like in CI)
+echo "=======================================" | tee -a "$SUMMARY_LOG"
+echo "Test Run Summary:" | tee -a "$SUMMARY_LOG"
+echo "- Coverage: ${COVERAGE_PCT}%" | tee -a "$SUMMARY_LOG"
+echo "- Threshold: ${MIN_COVERAGE}%" | tee -a "$SUMMARY_LOG"
+echo "- Exit Code: ${EXIT_CODE}" | tee -a "$SUMMARY_LOG"
+echo "Test run finished at $(date)" | tee -a "$SUMMARY_LOG"
+echo "=======================================" | tee -a "$SUMMARY_LOG"
+
+# Compare coverage percentage to minimum threshold
+# Use bc if available for floating point comparison, fallback to python
+if command -v bc >/dev/null 2>&1; then
+  if (( $(echo "$COVERAGE_PCT < $MIN_COVERAGE" | bc -l) )); then
+    echo -e "${RED}Coverage is below the minimum threshold!${NC}"
+    echo -e "${YELLOW}See detailed report in coverage_html/index.html${NC}"
+    exit 1
+  else
+    echo -e "${GREEN}Coverage meets or exceeds the minimum threshold!${NC}"
+    echo -e "${YELLOW}See detailed report in coverage_html/index.html${NC}"
+    exit 0
+  fi
+else
+  # Fallback to python if bc is not available
+  if python -c "exit(0 if float($COVERAGE_PCT) >= float($MIN_COVERAGE) else 1)"; then
+    echo -e "${GREEN}Coverage meets or exceeds the minimum threshold!${NC}"
+    echo -e "${YELLOW}See detailed report in coverage_html/index.html${NC}"
+    exit 0
+  else
+    echo -e "${RED}Coverage is below the minimum threshold!${NC}"
+    echo -e "${YELLOW}See detailed report in coverage_html/index.html${NC}"
+    exit 1
+  fi
+fi 

--- a/scripts/setup_pre_commit.sh
+++ b/scripts/setup_pre_commit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This script installs and sets up pre-commit hooks for the project
+
+# Exit on error
+set -e
+
+echo "Setting up pre-commit hooks for CLI Code..."
+
+# Check if pre-commit is installed
+if ! command -v pre-commit &> /dev/null; then
+    echo "Installing pre-commit..."
+    pip install pre-commit
+else
+    echo "pre-commit already installed. Checking for updates..."
+    pip install --upgrade pre-commit
+fi
+
+# Install the pre-commit hooks
+echo "Installing git hooks from .pre-commit-config.yaml..."
+pre-commit install
+
+# Run against all files (optional)
+echo "Running pre-commit on all files (first time may take a while)..."
+pre-commit run --all-files
+
+echo "✅ Pre-commit hooks have been configured successfully!"
+echo "Now Ruff linting and formatting will run automatically before each commit." 

--- a/src/cli_code/config.py
+++ b/src/cli_code/config.py
@@ -91,21 +91,21 @@ class Config:
             self.config_dir = default_dir
             self.config_file = default_dir / "config.yaml"
             log.debug(f"Using default config path: {self.config_file}")
-            return # Already set default paths
+            return  # Already set default paths
 
         if not config_path_str:
-             # Fallback if env var was empty string (should not happen with default logic, but safety)
-             log.warning("Config file path resolved to empty, falling back to default.")
-             home_dir = Path(os.path.expanduser("~"))
-             default_dir = home_dir / ".config" / "cli-code"
-             self.config_dir = default_dir
-             self.config_file = default_dir / "config.yaml"
-             source = "fallback default"
+            # Fallback if env var was empty string (should not happen with default logic, but safety)
+            log.warning("Config file path resolved to empty, falling back to default.")
+            home_dir = Path(os.path.expanduser("~"))
+            default_dir = home_dir / ".config" / "cli-code"
+            self.config_dir = default_dir
+            self.config_file = default_dir / "config.yaml"
+            source = "fallback default"
         else:
-             # Resolve the path (handles relative paths, expands ~)
-             self.config_file = Path(config_path_str).expanduser().resolve()
-             self.config_dir = self.config_file.parent
-             log.info(f"Using config path from {source}: {self.config_file}")
+            # Resolve the path (handles relative paths, expands ~)
+            self.config_file = Path(config_path_str).expanduser().resolve()
+            self.config_dir = self.config_file.parent
+            log.info(f"Using config path from {source}: {self.config_file}")
 
     def _load_dotenv(self):
         """Load environment variables from .env file if it exists, fallback to .env.example."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,7 +28,7 @@ def mock_home(tmp_path):
 @pytest.fixture
 def mock_config_paths(mock_home):
     """Fixture providing expected config paths based on mock_home."""
-    config_dir = mock_home / ".config" / "cli-code-agent"
+    config_dir = mock_home / ".config" / "cli-code"
     config_file = config_dir / "config.yaml"
     return config_dir, config_file
 
@@ -252,5 +252,119 @@ def test_config_env_var_override(mock_save, mock_load_config, mock_config_paths)
 # @patch('cli_code.config.Config._save_config')
 # def test_migrate_old_config_paths_logic(mock_save, mock_yaml_load, mock_open_func, mock_home):
 #    ... (implementation removed) ...
+
+
+# === Tests for Config Path Override ===
+
+@patch("cli_code.config.Config._load_dotenv", MagicMock())
+@patch("yaml.dump") # Mock yaml dump to prevent actual file writing
+@patch("builtins.open", new_callable=mock_open)
+@patch("pathlib.Path.exists")
+@patch("pathlib.Path.mkdir")
+def test_ensure_config_exists_creates_custom_path(mock_mkdir, mock_exists, mock_open_func, mock_yaml_dump, tmp_path):
+    """Test _ensure_config_exists creates file at a custom path provided via param."""
+    custom_dir = tmp_path / "custom_config_location"
+    custom_file = custom_dir / "my_config.yaml"
+
+    # Simulate file not existing
+    mock_exists.return_value = False
+
+    # Create a config with our custom path
+    with patch("cli_code.config.Config._load_config", return_value={}),\
+         patch("cli_code.config.Config._apply_env_vars"):
+        cfg = Config(config_file_path=custom_file)
+
+    # Assertions for _ensure_config_exists behavior
+    # It should have created the directory
+    mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    # It should have checked if the file exists
+    mock_exists.assert_called_with()
+    # It should have opened the custom file for writing
+    mock_open_func.assert_called_with(custom_file, "w")
+    # It should have dumped the default config
+    mock_yaml_dump.assert_called_once()
+    # Verify the paths stored in the instance are correct
+    assert cfg.config_dir == custom_dir
+    assert cfg.config_file == custom_file
+
+
+@patch("cli_code.config.Config._load_dotenv", MagicMock())
+@patch("cli_code.config.Config._ensure_config_exists", MagicMock())
+@patch("cli_code.config.Config._load_config") # Mock _load_config
+def test_config_load_from_env_var_path(mock_load_config, tmp_path):
+    """Test Config loads from path specified by CLI_CODE_CONFIG_FILE env var."""
+    custom_dir = tmp_path / "env_config_location"
+    custom_file = custom_dir / "env_config.yaml"
+    custom_data = {"key_from_env_file": "value_env"}
+
+    # Configure the mock _load_config to return data
+    # This implicitly tests that _load_config is called *after* the path is set correctly
+    mock_load_config.return_value = custom_data.copy()
+
+    # Set the environment variable
+    env_override = {"CLI_CODE_CONFIG_FILE": str(custom_file)}
+    with patch.dict(os.environ, env_override, clear=True):
+        cfg = Config()
+
+    # Check that _load_config was called
+    mock_load_config.assert_called_once()
+    # Check that the loaded config contains our custom data key
+    assert cfg.config.get("key_from_env_file") == custom_data["key_from_env_file"]
+    # Verify the config paths are correct (set during __init__)
+    assert cfg.config_file == custom_file
+    assert cfg.config_dir == custom_dir
+
+
+@patch("cli_code.config.Config._load_dotenv", MagicMock())
+@patch("cli_code.config.Config._ensure_config_exists", MagicMock())
+@patch("cli_code.config.Config._load_config") # Mock _load_config
+def test_config_load_from_param_path(mock_load_config, tmp_path):
+    """Test Config loads from path specified by __init__ parameter."""
+    param_dir = tmp_path / "param_config_location"
+    param_file = param_dir / "param_config.yaml"
+    param_data = {"key_from_param_file": "value_param"}
+
+    # Mock the load result
+    mock_load_config.return_value = param_data.copy()
+
+    with patch.dict(os.environ, {}, clear=True): # Ensure no env var interference
+        cfg = Config(config_file_path=param_file)
+
+    mock_load_config.assert_called_once()
+    assert cfg.config.get("key_from_param_file") == param_data["key_from_param_file"]
+    assert cfg.config_file == param_file
+    assert cfg.config_dir == param_dir
+
+
+@patch("cli_code.config.Config._load_dotenv", MagicMock())
+@patch("cli_code.config.Config._ensure_config_exists", MagicMock())
+@patch("cli_code.config.Config._load_config") # Mock _load_config
+def test_config_param_overrides_env_var_path(mock_load_config, tmp_path):
+    """Test Config parameter path takes precedence over environment variable path."""
+    env_dir = tmp_path / "env_config_location_prio"
+    env_file = env_dir / "env_config_prio.yaml"
+
+    param_dir = tmp_path / "param_config_location_prio"
+    param_file = param_dir / "param_config_prio.yaml"
+    param_data = {"key": "param"}
+
+    # Mock _load_config to return the data we expect from the parameter path
+    mock_load_config.return_value = param_data.copy()
+
+    # Set the environment variable (should be ignored)
+    env_override = {"CLI_CODE_CONFIG_FILE": str(env_file)}
+    with patch.dict(os.environ, env_override, clear=True):
+        # Instantiate with the parameter path
+        cfg = Config(config_file_path=param_file)
+
+    # Assert that _load_config was called
+    mock_load_config.assert_called_once()
+    # Check the key from param_data is in the config
+    assert cfg.config.get("key") == param_data["key"]
+    # The config may include more keys (like an empty settings dict) - that's expected
+    # Verify the path stored in the instance is the parameter path
+    assert cfg.config_file == param_file
+    assert cfg.config_dir == param_dir
+
 
 # End of file

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,8 +256,9 @@ def test_config_env_var_override(mock_save, mock_load_config, mock_config_paths)
 
 # === Tests for Config Path Override ===
 
+
 @patch("cli_code.config.Config._load_dotenv", MagicMock())
-@patch("yaml.dump") # Mock yaml dump to prevent actual file writing
+@patch("yaml.dump")  # Mock yaml dump to prevent actual file writing
 @patch("builtins.open", new_callable=mock_open)
 @patch("pathlib.Path.exists")
 @patch("pathlib.Path.mkdir")
@@ -270,8 +271,7 @@ def test_ensure_config_exists_creates_custom_path(mock_mkdir, mock_exists, mock_
     mock_exists.return_value = False
 
     # Create a config with our custom path
-    with patch("cli_code.config.Config._load_config", return_value={}),\
-         patch("cli_code.config.Config._apply_env_vars"):
+    with patch("cli_code.config.Config._load_config", return_value={}), patch("cli_code.config.Config._apply_env_vars"):
         cfg = Config(config_file_path=custom_file)
 
     # Assertions for _ensure_config_exists behavior
@@ -290,7 +290,7 @@ def test_ensure_config_exists_creates_custom_path(mock_mkdir, mock_exists, mock_
 
 @patch("cli_code.config.Config._load_dotenv", MagicMock())
 @patch("cli_code.config.Config._ensure_config_exists", MagicMock())
-@patch("cli_code.config.Config._load_config") # Mock _load_config
+@patch("cli_code.config.Config._load_config")  # Mock _load_config
 def test_config_load_from_env_var_path(mock_load_config, tmp_path):
     """Test Config loads from path specified by CLI_CODE_CONFIG_FILE env var."""
     custom_dir = tmp_path / "env_config_location"
@@ -317,7 +317,7 @@ def test_config_load_from_env_var_path(mock_load_config, tmp_path):
 
 @patch("cli_code.config.Config._load_dotenv", MagicMock())
 @patch("cli_code.config.Config._ensure_config_exists", MagicMock())
-@patch("cli_code.config.Config._load_config") # Mock _load_config
+@patch("cli_code.config.Config._load_config")  # Mock _load_config
 def test_config_load_from_param_path(mock_load_config, tmp_path):
     """Test Config loads from path specified by __init__ parameter."""
     param_dir = tmp_path / "param_config_location"
@@ -327,7 +327,7 @@ def test_config_load_from_param_path(mock_load_config, tmp_path):
     # Mock the load result
     mock_load_config.return_value = param_data.copy()
 
-    with patch.dict(os.environ, {}, clear=True): # Ensure no env var interference
+    with patch.dict(os.environ, {}, clear=True):  # Ensure no env var interference
         cfg = Config(config_file_path=param_file)
 
     mock_load_config.assert_called_once()
@@ -338,7 +338,7 @@ def test_config_load_from_param_path(mock_load_config, tmp_path):
 
 @patch("cli_code.config.Config._load_dotenv", MagicMock())
 @patch("cli_code.config.Config._ensure_config_exists", MagicMock())
-@patch("cli_code.config.Config._load_config") # Mock _load_config
+@patch("cli_code.config.Config._load_config")  # Mock _load_config
 def test_config_param_overrides_env_var_path(mock_load_config, tmp_path):
     """Test Config parameter path takes precedence over environment variable path."""
     env_dir = tmp_path / "env_config_location_prio"


### PR DESCRIPTION
## Overview
This PR enhances the configuration system by adding flexibility in how users can specify the config file path. It also streamlines the README to focus on essential information and point to detailed docs.

## Key Features
- **Configuration Path Flexibility**: Users can now specify a custom config file path in three ways:
  1. Directly via the `config_file_path` parameter when creating a `Config` instance
  2. Through the `CLI_CODE_CONFIG_FILE` environment variable
  3. Fallback to the default path (`~/.config/cli-code/config.yaml`)

- **Clear Priority Order**: When multiple configuration sources exist, they follow a predictable priority:
  Parameter > Environment Variable > Default Path

- **Developer Experience**: Updated docstrings and improved error handling make the configuration system more robust and easier to understand.

## Documentation & Testing
- Simplified README.md by removing duplicate content covered in docs/ directory
- Reorganized content to highlight essential information first
- Added comprehensive tests for the new configuration path override functionality
- Fixed test issues by properly mocking `_load_config` to prevent hangs

## Addresses Review Comments
- Improved logging consistency across the configuration loading process
- Fixed the mock_config_paths fixture to use the correct directory name ('cli-code')
- Added proper assertions in tests to verify behavior with custom config paths